### PR TITLE
added support for OS_ENDPOINT_TYPE

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,13 @@ import Swifft from 'swifft';
 // These are the default env vars used internally by swifft.
 // Usage here is for demonstration purposes only.
 let options = {
-    auth_url =    process.env.OS_AUTH_URL,
-    tenant_id =   process.env.OS_TENANT_ID,
-    tenant_name = process.env.OS_TENANT_NAME,
-    region =      process.env.OS_REGION_NAME,
-    username =    process.env.OS_USERNAME,
-    password =    process.env.OS_PASSWORD
+    auth_url =      process.env.OS_AUTH_URL,
+    tenant_id =     process.env.OS_TENANT_ID,
+    tenant_name =   process.env.OS_TENANT_NAME,
+    endpoint_type = process.env.OS_ENDPOINT_TYPE,
+    region =        process.env.OS_REGION_NAME,
+    username =      process.env.OS_USERNAME,
+    password =      process.env.OS_PASSWORD
 }
 
 

--- a/bin/swifft.js
+++ b/bin/swifft.js
@@ -6,22 +6,24 @@ import Swifft from '../index.js';
 
 const argv = minimist(process.argv.slice(2), {
     alias: {
-        'os_auth_url':    'a',
-        'os_tenant_id':   'i',
-        'os_tenant_name': 'n',
-        'os_username':    'u',
-        'os_password':    'p',
-        'region':         'r'
+        'os_auth_url':      'a',
+        'os_tenant_id':     'i',
+        'os_tenant_name':   'n',
+        'os_username':      'u',
+        'os_password':      'p',
+        'os_endpoint_type': 'e',
+        'region':           'r'
     },
     default: {
         /*
          // These defaults live in the lib/swifft_account.js implementation.
-         'os_auth_url':    process.env.OS_AUTH_URL,
-         'os_tenant_id':   process.env.OS_TENANT_ID,
-         'os_tenant_name': process.env.OS_TENANT_NAME,
-         'os_username':    process.env.OS_USERNAME,
-         'os_password':    process.env.OS_PASSWORD,
-         'region':         process.env.OS_REGION_NAME
+         'os_auth_url':      process.env.OS_AUTH_URL,
+         'os_tenant_id':     process.env.OS_TENANT_ID,
+         'os_tenant_name':   process.env.OS_TENANT_NAME,
+         'os_username':      process.env.OS_USERNAME,
+         'os_password':      process.env.OS_PASSWORD,
+         'os_endpoint_type': process.env.OS_ENDPOINT_TYPE,
+         'region':           process.env.OS_REGION_NAME
          */
     }
 });

--- a/lib/swifft_account.js
+++ b/lib/swifft_account.js
@@ -12,16 +12,18 @@ export default class SwifftAccount {
 
     constructor(options = {}) {
         let {   auth_url =    ENV.OS_AUTH_URL,
-              tenant_id =   ENV.OS_TENANT_ID,
-              tenant_name = ENV.OS_TENANT_NAME,
-              region =      ENV.OS_REGION_NAME,
-              username =    ENV.OS_USERNAME,
-              password =    ENV.OS_PASSWORD } = options;
+              tenant_id =     ENV.OS_TENANT_ID,
+              tenant_name =   ENV.OS_TENANT_NAME,
+              endpoint_type = ENV.OS_ENDPOINT_TYPE,
+              region =        ENV.OS_REGION_NAME,
+              username =      ENV.OS_USERNAME,
+              password =      ENV.OS_PASSWORD } = options;
 
         this.auth_url = Url.parse(auth_url);
         this.tenant_id = tenant_id;
         this.tenant_name = tenant_name;
         this.region = region;
+        this.endpoint_type = endpoint_type;
 
         this.storage_url = {};
         this.id = undefined;
@@ -128,7 +130,22 @@ export default class SwifftAccount {
                     if (type === 'object-store' && name === 'swift') {
                         for (let endpoint of endpoints) {
                             if (endpoint.region && this.region && endpoint.region.toLowerCase() === this.region.toLowerCase()) {
-                                this.storage_url = Url.parse(endpoint.publicURL || endpoint.internalURL);
+                                switch (this.endpoint_type) {
+                                    case 'adminURL':
+                                        this.storage_url = Url.parse(endpoint.adminURL);
+                                        break;
+
+                                    case 'internalURL':
+                                        this.storage_url = Url.parse(endpoint.internalURL);
+                                        break;
+
+                                    case 'publicURL':
+                                        this.storage_url = Url.parse(endpoint.publicURL);
+                                        break;
+
+                                    default:
+                                        this.storage_url = Url.parse(endpoint.publicURL || endpoint.internalURL);
+                                }
                                 break services;
                             }
                         }


### PR DESCRIPTION
This pull request aims to add support for OS_ENDPOINT_TYPE.

Now it's possible to choose a specific endpoint type.
Possible type values are: 
- _adminURL_;
- _internalURL_; and
- _publicURL_.

If none is provided, the default behaviour is as it was.
