### PR TITLE
Corrected copy to match swift documentation

### DIFF
--- a/lib/swifft_object.js
+++ b/lib/swifft_object.js
@@ -114,7 +114,7 @@ export default class SwiftObject {
         let opts = {
             method: 'COPY',
             headers: {
-                'Destination': `${container}/${object}`
+                'Destination': `/${container}/${object}`
             }
         };
 


### PR DESCRIPTION
Destination requires a trailing slash.
https://developer.openstack.org/api-ref/object-storage/?expanded=copy-object-detail

Fixes #5